### PR TITLE
Initial launch bug

### DIFF
--- a/Sources/LocationProvider/LocationProvider.swift
+++ b/Sources/LocationProvider/LocationProvider.swift
@@ -160,6 +160,10 @@ extension LocationProvider: CLLocationManagerDelegate {
         print(#function, status.name)
         #endif
         //print()
+     
+        if status == .authorizedAlways || status == .authorizedWhenInUse {
+            self.lm.startUpdatingLocation()
+        }
     }
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {


### PR DESCRIPTION
The first time you launch an app with this code you get a dialog box asking for permissions. If you don't click it immediately but wait just a second or so before clicking allow, you have to force quit and start the app to get position updates. I believe this fixes #6